### PR TITLE
Update Ignore: Remove DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-.DS_Store


### PR DESCRIPTION
Removes `.DS_Store` from `.gitignore` in favor of having a developer add it to their machine’s global ignore.